### PR TITLE
build(devshell): add `convco` to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
 
           # Additional dev-shell environment variables can be set directly
           # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
-          packages = with pkgs; [rustup toolchain just zip reuse pkg-config openssl statix] ++ self.checks.${system}.pre-commit-check.enabledPackages;
+          packages = with pkgs; [rustup toolchain just zip reuse pkg-config openssl statix convco] ++ self.checks.${system}.pre-commit-check.enabledPackages;
           inherit (self.checks.${system}.pre-commit-check) shellHook;
         };
 


### PR DESCRIPTION
Convco makes it easier for devs new to conventional commits to get used to the
standard. We provide it in the devshell to make reduce friction when
onboarding.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>
